### PR TITLE
Bugfix to allow venv to source the correct ensurepip wheel file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Setup python virtual environments for Windows
 
+<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+
 To run the script test.py with a virtual python environment, 
 double click/execute the test.bat file.
 That's it.

--- a/setup.py
+++ b/setup.py
@@ -162,9 +162,9 @@ def main() -> None:
             "\nUse custom workaround."
         )
         run(f'"{PYTHON}" -m venv {VENV_PATH} --without-pip')
-        whl = list(Path(ensurepip.__path__[0]).glob("_bundled/pip*.whl"))[0]
+        whl = next(Path(ensurepip.__path__[0]).glob("_bundled/pip*.whl"))
         # # Could also be
-        # whl = next(Path(ensurepip.__path__[0]).glob("_bundled/pip*.whl")))
+        # whl = list(Path(ensurepip.__path__[0]).glob("_bundled/pip*.whl"))[0]
         print("Your pip wheel file to use:", whl)
         # All variables set; moving on to executing venv pip install.
         run(

--- a/setup.py
+++ b/setup.py
@@ -143,11 +143,9 @@ def main() -> None:
         return
 
     activate = activate_command()
-
     PYTHON = python_interpreter_path()
-    # print(PYTHON)
-    # # https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
-    # run(f"{PYTHON} -m venv {VENV_PATH}")
+
+    # https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
     try:
         run(f'"{PYTHON}" -m venv {VENV_PATH}')
         run(
@@ -172,8 +170,6 @@ def main() -> None:
         )
     run(f"{activate} python -m pip install -r {requirements_in_path}")
     run(f"{activate} python -m pip freeze > {requirements_txt_path}")
-    # run(f"{activate} pip-compile {requirements_in_path} -o {requirements_txt_path}")
-    # run(f"{activate} python -m pip install -r {requirements_txt_path}")
     print("Venv setup executed.")
 
 


### PR DESCRIPTION
In case the setting up of the venv does weird things to try to source from nonexistent pip wheels in the ensurepip package of the user's base interpreter, this lets the code source from the existing pip wheel file. 
![image](https://user-images.githubusercontent.com/40374786/188229500-96780d55-d684-48a3-8bde-0128c2192093.png)
![image](https://user-images.githubusercontent.com/40374786/188229557-2cac5093-1592-44e0-bb72-30272ef2e46c.png)
